### PR TITLE
feat: json에서 여행 기록 조회, 삭제 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.28'
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.10.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.5.0'
+    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '5.5.0'
 }
 
 test {

--- a/src/main/java/domain/trip/exception/TripFileNotFoundException.java
+++ b/src/main/java/domain/trip/exception/TripFileNotFoundException.java
@@ -1,0 +1,8 @@
+package domain.trip.exception;
+
+public class TripFileNotFoundException extends RuntimeException {
+
+    public TripFileNotFoundException() {
+        super("여행 파일을 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/domain/trip/service/TripService.java
+++ b/src/main/java/domain/trip/service/TripService.java
@@ -1,0 +1,106 @@
+package domain.trip.service;
+
+import domain.trip.dto.TripDTO;
+import domain.trip.exception.TripFileNotFoundException;
+import global.util.JsonUtil;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TripService {
+
+    private static final String JSONPATH = "src/main/resources/trip/json";
+
+    /**
+     * json 에서 전체 여행 기록을 조회 하는 메서드
+     *
+     * @return src/main/resources/trip/json Directory 내 json 에서 읽어온 TripDTO List 객체
+     */
+    public List<TripDTO> getTripListFromJson() {
+        List<TripDTO> tripList = new ArrayList<>();
+        BufferedReader br = null;
+        File[] files = new File(JSONPATH).listFiles();
+        if (files == null) {
+            throw new TripFileNotFoundException();
+        }
+        for (File file : files) {
+            if (!file.isFile() || !file.canRead()) {
+                continue;
+            }
+            try {
+                br = new BufferedReader(new FileReader(file));
+                TripDTO trip = JsonUtil.fromJson(br, TripDTO.class);
+                tripList.add(trip);
+            } catch (Exception e) {
+                e.printStackTrace();
+            } finally {
+                try {
+                    if (br != null) {
+                        br.close();
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        return tripList;
+    }
+
+    /**
+     * json 에서 특정 여행 기록을 조회 하는 메서드
+     *
+     * @param id 조회할 특정 여행 기록 trip_id 값
+     * @return src/main/resources/trip/json Directory 내 여행 기록 id에 해당 하는 json 에서 읽어온 TripDTO 객체
+     */
+    public TripDTO getTripFromJson(int id) {
+        TripDTO trip = null;
+        BufferedReader br = null;
+        File file = new File(JSONPATH + "/trip_" + id + ".json");
+        if (!file.isFile() || !file.canRead()) {
+            throw new TripFileNotFoundException();
+        }
+        try {
+            br = new BufferedReader(new FileReader(file));
+            trip = JsonUtil.fromJson(br, TripDTO.class);
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            try {
+                if (br != null) {
+                    br.close();
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+        if (trip == null) {
+            throw new TripFileNotFoundException();
+        }
+        return trip;
+    }
+
+    /**
+     * 특정 여행 기록 json 을 삭제 하는 메서드
+     *
+     * @param id 삭제할 특정 여행 기록 trip_id 값
+     * @return src/main/resources/trip/json Directory 내 여행 기록 id에 해당 하는 json 삭제 성공 여부(삭제 성공: true,
+     * 삭제 실패: false)
+     */
+    public boolean deleteTripFromJson(int id) {
+        Path filePath = Paths.get(JSONPATH + "/trip_" + id + ".json");
+        try {
+            return Files.deleteIfExists(filePath);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+    // TODO csv 파일에서 전체 여행 기록 조회 메서드 구현
+    // TODO csv 파일에서 특정 여행 기록 조회 메서드 구현
+    // TODO 특정 여행 기록 csv 삭제 메서드 구현
+}

--- a/src/main/java/domain/trip/service/TripService.java
+++ b/src/main/java/domain/trip/service/TripService.java
@@ -23,7 +23,6 @@ public class TripService {
      */
     public List<TripDTO> getTripListFromJson() {
         List<TripDTO> tripList = new ArrayList<>();
-        BufferedReader br = null;
         File[] files = new File(JSONPATH).listFiles();
         if (files == null) {
             throw new TripFileNotFoundException();
@@ -32,20 +31,11 @@ public class TripService {
             if (!file.isFile() || !file.canRead()) {
                 continue;
             }
-            try {
-                br = new BufferedReader(new FileReader(file));
+            try (BufferedReader br = new BufferedReader(new FileReader(file));) {
                 TripDTO trip = JsonUtil.fromJson(br, TripDTO.class);
                 tripList.add(trip);
             } catch (Exception e) {
                 e.printStackTrace();
-            } finally {
-                try {
-                    if (br != null) {
-                        br.close();
-                    }
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
             }
         }
         return tripList;
@@ -59,24 +49,14 @@ public class TripService {
      */
     public TripDTO getTripFromJson(int id) {
         TripDTO trip = null;
-        BufferedReader br = null;
         File file = new File(JSONPATH + "/trip_" + id + ".json");
         if (!file.isFile() || !file.canRead()) {
             throw new TripFileNotFoundException();
         }
-        try {
-            br = new BufferedReader(new FileReader(file));
+        try (BufferedReader br = new BufferedReader(new FileReader(file));) {
             trip = JsonUtil.fromJson(br, TripDTO.class);
         } catch (Exception e) {
             e.printStackTrace();
-        } finally {
-            try {
-                if (br != null) {
-                    br.close();
-                }
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
         }
         if (trip == null) {
             throw new TripFileNotFoundException();

--- a/src/test/java/domain/trip/service/TripServiceTest.java
+++ b/src/test/java/domain/trip/service/TripServiceTest.java
@@ -121,7 +121,7 @@ public class TripServiceTest {
 
         @Test
         @DisplayName("해달 여핼 기록이 없으면 여행 기록을 삭제할 수 없다.")
-        void TripFileNotFound_willFail() {
+        void tripFileNotFound_willFail() {
             // given, when
             boolean result = tripService.deleteTripFromJson(1);
 

--- a/src/test/java/domain/trip/service/TripServiceTest.java
+++ b/src/test/java/domain/trip/service/TripServiceTest.java
@@ -1,0 +1,132 @@
+package domain.trip.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import domain.trip.dto.TripDTO;
+import domain.trip.exception.TripFileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class TripServiceTest {
+
+    TripService tripService = new TripService();
+
+    @Mock
+    TripService mockTripService = new TripService();
+
+    @Nested
+    @DisplayName("getTripListFromJson()는 ")
+    class Context_getTripList {
+
+        @Test
+        @DisplayName("전체 여행 기록을 조회할 수 있다.")
+        void _willSuccess() {
+            // given
+            List<TripDTO> tripList = new ArrayList<>();
+            tripList.add(TripDTO.builder().name("Family Vacation").build());
+            when(mockTripService.getTripListFromJson()).thenReturn(tripList);
+
+            // when
+            List<TripDTO> result = mockTripService.getTripListFromJson();
+
+            //then
+            Assertions.assertEquals(result, tripList);
+        }
+
+        @Test
+        @DisplayName("여행 기록이 없으면 조회할 수 없다.")
+        void tripFileNotFound_willFail() {
+            // given, when
+            when(mockTripService.getTripListFromJson()).thenThrow(new TripFileNotFoundException());
+
+            // then
+            Throwable exception = assertThrows(TripFileNotFoundException.class, () -> {
+                mockTripService.getTripListFromJson();
+            });
+            assertEquals("여행 파일을 찾을 수 없습니다.", exception.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("getTripFromJson()는")
+    class Context_getTripFromJson {
+
+        @Test
+        @DisplayName("특정 여행 기록을 조회할 수 있다.")
+        void _willSuccess() {
+            // given
+            TripDTO trip = TripDTO.builder().id(1).build();
+            when(mockTripService.getTripFromJson(1)).thenReturn(trip);
+
+            // when
+            TripDTO result = mockTripService.getTripFromJson(1);
+
+            // then
+            Assertions.assertEquals(result.getId(), trip.getId());
+        }
+
+        @Test
+        @DisplayName("특정 여행 기록이 없으면 조회할 수 없다.")
+        void tripFileNotFound_willFail() {
+            // given, when, then
+            Throwable exception = assertThrows(TripFileNotFoundException.class, () -> {
+                tripService.getTripFromJson(2);
+            });
+            assertEquals("여행 파일을 찾을 수 없습니다.", exception.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteTrip()은")
+    class Context_deleteTrip {
+
+        @Test
+        @DisplayName("여행 기록을 삭제할 수 있다.")
+        void _willSuccess() {
+            // given
+            // Test 를 위해 삭제할 파일 생성
+            FileWriter fw = null;
+            try {
+                fw = new FileWriter("src/main/resources/trip/json/trip_1.json");
+            } catch (Exception e) {
+                e.printStackTrace();
+            } finally {
+                try {
+                    if (fw != null) {
+                        fw.close();
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            // when
+            boolean result = tripService.deleteTripFromJson(1);
+
+            // then
+            Assertions.assertTrue(result);
+        }
+
+        @Test
+        @DisplayName("해달 여핼 기록이 없으면 여행 기록을 삭제할 수 없다.")
+        void TripFileNotFound_willFail() {
+            // given, when
+            boolean result = tripService.deleteTripFromJson(1);
+
+            // then
+            Assertions.assertFalse(result);
+        }
+    }
+}


### PR DESCRIPTION
# feat: json에서 여행 기록 조회, 삭제 기능 구현

## [의존성 추가]
원활한 테스트를 위해 몇 가지 의존성을 추가했습니다. 
- junit-jupiter-api
- mockito-core
- mockito-junit-jupater

## [개발 내용]
- **Test 코드 작성**
  - json 에서 전체 여행 기록 조회 기능 테스트
  - json 에서 특정 여행 기록 조회 기능 테스트
  - 특정 여행 기록  json 삭제 기능 테스트
  - 테스트를 위한 sample 여행 기록 json 생성 코드
- **Exception 추가**
  - TripFileNotFoundException(): 조회할 여행 파일 부재 Exception
- **기능 구현**
  - getTripListFromJson(): json에서 전체 여행 기록 조회
  - getTripFromJson(): json에서 특정 여행 기록 조회
  - deleteTripFromJson(): 특정 여행 기록 json 삭제

## [TODO]
CSV 파일 파싱 기능 구현 이후 추가할 개발 내용입니다. 
- csv에서 전체 여행 기록 조회
- csv에서 특정 여행 기록 조회
- 특정 여행 기록 csv 삭제