### PR TITLE
feat: CsvUtil 클래스의 toCsv()와 fromCsv()에 유림님이 요청하신 header와 데이터 저장 관련 기능 추가 및 수정

### DIFF
--- a/src/main/java/global/util/CsvUtil.java
+++ b/src/main/java/global/util/CsvUtil.java
@@ -1,16 +1,23 @@
 package global.util;
 
+import com.opencsv.CSVWriter;
+import com.opencsv.ICSVWriter;
+import com.opencsv.bean.CsvBindByName;
+import com.opencsv.bean.CsvBindByPosition;
 import com.opencsv.bean.CsvToBean;
 import com.opencsv.bean.CsvToBeanBuilder;
 import com.opencsv.bean.StatefulBeanToCsv;
 import com.opencsv.bean.StatefulBeanToCsvBuilder;
 import com.opencsv.exceptions.CsvDataTypeMismatchException;
 import com.opencsv.exceptions.CsvRequiredFieldEmptyException;
-import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Reader;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * CSV 파싱 유틸 클래스
@@ -19,10 +26,11 @@ import java.util.List;
  * @since 2023-09-06
  */
 public class CsvUtil {
+
     /**
      * 객체를 직렬화 하여 csv파일을 만들어 filePath 위치에 저장하는 메서드
      *
-     * @param objects csv파일로 저장할 Object List
+     * @param objects  csv파일로 저장할 Object List
      * @param filePath 파일을 저장할 경로 ex) "./src/main/resources/trip/output.csv"
      * @throws IOException
      * @throws CsvRequiredFieldEmptyException
@@ -30,24 +38,53 @@ public class CsvUtil {
      */
     public static <T> void toCsv(List<T> objects, String filePath)
         throws IOException, CsvRequiredFieldEmptyException, CsvDataTypeMismatchException {
-        BufferedWriter writer = new BufferedWriter(new FileWriter(filePath));
-        StatefulBeanToCsv beanToCsv = new StatefulBeanToCsvBuilder(writer).build();
+
+        CSVWriter writer = new CSVWriter(new FileWriter(filePath));
+
+        // 클래스의 필드 배열을 가져옵니다.
+        Field[] fields = objects.get(0).getClass().getDeclaredFields();
+
+        // 필드를 @CsvBindByPosition의 position 값으로 정렬합니다.
+        List<Field> sortedFields =
+            Arrays.stream(fields)
+                  .filter(field -> field.isAnnotationPresent(CsvBindByPosition.class))
+                  .sorted(Comparator.comparingInt(
+                      f -> f.getAnnotation(CsvBindByPosition.class).position()))
+                  .collect(Collectors.toList());
+
+        // 정렬된 필드를 기반으로 헤더를 생성합니다.
+        String[] header = sortedFields.stream()
+                                      .map(field -> field.getAnnotation(CsvBindByName.class)
+                                                         .column())
+                                      .toArray(String[]::new);
+        // StatefulBeanToCsv 설정
+        StatefulBeanToCsv beanToCsv = new StatefulBeanToCsvBuilder(writer)
+            .withApplyQuotesToAll(false)
+            .build();
+
+        // header 저장
+        writer.writeNext(header,false);
+
+        // body 저장
         beanToCsv.write(objects);
+
+        // 파일 닫기
         writer.close();
     }
 
     /**
      * csv파일을 읽어 객체로 역직렬화하는 메서드
      *
-     * @param reader csv 파일을 읽을 Reader
+     * @param reader   csv 파일을 읽을 Reader
      * @param classOfT csv 파일을 객체화 시킬 클래스
-     * @param <T> csv 파일을 객체화 시킬 클래스 타입
+     * @param <T>      csv 파일을 객체화 시킬 클래스 타입
      * @return 역직렬화 된 객체 리스트
      */
     public static <T> List<T> fromCsv(Reader reader, Class<T> classOfT) {
         CsvToBean<T> csvToBean = new CsvToBeanBuilder<T>(reader)
             .withType(classOfT)
             .withIgnoreLeadingWhiteSpace(true) // 헤더 및 데이터에서 앞쪽의 공백 문자를 무시하도록 설정
+            .withSkipLines(1)
             .build();
 
         return csvToBean.parse();

--- a/src/test/java/global/util/CsvUtilTest.java
+++ b/src/test/java/global/util/CsvUtilTest.java
@@ -1,6 +1,7 @@
 package global.util;
 
 import com.opencsv.bean.CsvBindByName;
+import com.opencsv.bean.CsvBindByPosition;
 import com.opencsv.bean.CsvDate;
 import java.io.File;
 import java.io.StringReader;
@@ -35,7 +36,7 @@ class CsvUtilTest {
                     "3,Family Vacation3,2023-07-17,2023-07-22,15:00:00,2023-07-22T15:00:00\n" +
                     "4,Family Vacation4,2023-07-18,2023-07-23,16:00:00,2023-07-15T16:00:00\n";
             List<TripTestDTO> trips = CsvUtil.fromCsv(new StringReader(csv), TripTestDTO.class);
-            String filePath = "./src/test/java/global/util/a.csv";
+            String filePath = "src/test/java/global/util/a.csv";
 
             try {
                 // CSV 파일 저장
@@ -133,22 +134,29 @@ class CsvUtilTest {
         }
     }
 
+
     public static class TripTestDTO {
 
         @CsvBindByName(column = "trip_id", required = true)
+        @CsvBindByPosition(position = 0)
         private Long tripId;
         @CsvBindByName(column = "trip_name", required = true)
+        @CsvBindByPosition(position = 1)
         private String tripName;
         @CsvBindByName(column = "start_date", required = true)
+        @CsvBindByPosition(position = 2)
         @CsvDate("yyyy-MM-dd")
         private LocalDate startDate;
         @CsvBindByName(column = "end_date", required = true)
+        @CsvBindByPosition(position = 3)
         @CsvDate("yyyy-MM-dd")
         private LocalDate endDate;
         @CsvBindByName(column = "time", required = true)
+        @CsvBindByPosition(position = 4)
         @CsvDate("HH:mm:ss")
         private LocalTime time;
         @CsvBindByName(column = "datetime", required = true)
+        @CsvBindByPosition(position = 5)
         @CsvDate("yyyy-MM-dd'T'HH:mm:ss")
         private LocalDateTime datetime;
 


### PR DESCRIPTION
## [개발내용]

- 유림님이 요청하셨던 기능개발
  -  CSV header를 저장할 때 DTO에 선언 되어있는 필드 순서대로 저장하는 기능 구현하였습니다!
  -  기존 CSV를 저장하면 ""가 붙어서 저장되는 것을 더 이상 ""가 안 붙고 저장되도록 수정하였습니다!

- 추가
  - Test코드에 작성된 DTO를 참고하셔서 기존 TripCsvDTO에 @CsvBindByPosition(position= 0~N까지)를 넣어주셔야 정상적으로 정렬되어서 저장이 됩니다!