### PR TITLE
fix : Itinerary Trip test 파일 생성 후 삭제

### DIFF
--- a/src/main/java/domain/itinerary/service/ItineraryService.java
+++ b/src/main/java/domain/itinerary/service/ItineraryService.java
@@ -45,7 +45,7 @@ public class ItineraryService {
 
         String jsonFilePath = JSONPATH + "/trip_" + tripId + ".json";
 
-        if (trip.getItineraries() != null) {
+        if (!trip.getItineraries().isEmpty()) {
             File file = new File(jsonFilePath);
             if (!file.isFile() || !file.canRead()) {
                 throw new TripFileNotFoundException();
@@ -116,8 +116,14 @@ public class ItineraryService {
 
         List<TripCsvDTO> tripCsvList = fileUtil.readCsvFile(csvFilePath);
         for (TripCsvDTO tripCsv : tripCsvList) {
-            ItineraryDTO itinerary = tripCsv.toItineraryDTO();
-            itineraryList.add(itinerary);
+            Integer id = tripCsv.getItineraryId();
+            if(id != 0){
+                ItineraryDTO itinerary = tripCsv.toItineraryDTO();
+                itineraryList.add(itinerary);
+            } else {
+                //Itinerary 기록하기 API로 연동
+            }
+
         }
         return itineraryList;
 
@@ -176,6 +182,7 @@ public class ItineraryService {
         }
         return false;
     }
+
 
 }
 

--- a/src/test/java/domain/itinerary/service/ItineraryServiceTest.java
+++ b/src/test/java/domain/itinerary/service/ItineraryServiceTest.java
@@ -3,7 +3,6 @@ package domain.itinerary.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.when;
 
 import domain.itinerary.dto.ItineraryDTO;
 import domain.itinerary.exception.ItineraryNotFoundException;
@@ -12,6 +11,8 @@ import domain.trip.exception.TripFileNotFoundException;
 import domain.trip.service.TripService;
 import global.dto.TripCsvDTO;
 import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -35,20 +36,22 @@ public class ItineraryServiceTest {
 
     @Nested
     @DisplayName("getItineraryListFromJson()은")
-    class Context_getItineraryListFromTrip {
+    class Context_getItineraryListFromJson {
 
         @Test
         @DisplayName("특정 여행의 여정 기록을 조회할 수 있다.")
         void _willSuccess() throws FileNotFoundException {
             //given
+            postFileJSON();
             List<ItineraryDTO> itineraryList = new ArrayList<>();
             itineraryList.add(ItineraryDTO.builder().id(1).build());
-            when(mockItineraryService.getItineraryListFromJson(1)).thenReturn(itineraryList);
+            lenient().when(mockItineraryService.getItineraryListFromJson(3)).thenReturn(itineraryList);
 
             //when
-            List<ItineraryDTO> result = itineraryService.getItineraryListFromJson(1);
+            List<ItineraryDTO> result = itineraryService.getItineraryListFromJson(3);
 
             //then
+            tripService.deleteTripFromJson(3);
             Assertions.assertEquals(result.get(0).getId(), itineraryList.get(0).getId());
         }
 
@@ -56,7 +59,7 @@ public class ItineraryServiceTest {
         @DisplayName("특정 여행 기록이 없으면 조회할 수 없다.")
         void tripFileNotFound_willFail() {
             Throwable exception = assertThrows(TripFileNotFoundException.class, () -> {
-                tripService.getTripFromJson(3);
+                tripService.getTripFromJson(5);
             });
             assertEquals("여행 파일을 찾을 수 없습니다.", exception.getMessage());
         }
@@ -71,14 +74,10 @@ public class ItineraryServiceTest {
         @Test
         @DisplayName("특정 여정을 삭제할 수 있다.")
         void _willSuccess() throws ItineraryNotFoundException {
-            //given
-            List<ItineraryDTO> itineraryList = new ArrayList<>();
-            ItineraryDTO itinerary = ItineraryDTO.builder().id(4).build();
-            itineraryList.add(itinerary);
-            TripDTO trip = TripDTO.builder().id(1).itineraries(itineraryList).build();
-
-            //when
-            boolean result = itineraryService.deleteItineraryFromJson(1, 4);
+            //given, when
+            postFileJSON();
+            boolean result = itineraryService.deleteItineraryFromJson(3, 1);
+            tripService.deleteTripFromJson(3);
 
             //then
             Assertions.assertTrue(result);
@@ -93,18 +92,20 @@ public class ItineraryServiceTest {
         @DisplayName("특정 여행의 여정 기록을 조회할 수 있다.")
         void _willSuccess() throws FileNotFoundException {
             //given
+            postFileCSV();
             ItineraryDTO itinerary = TripCsvDTO.builder()
-                .tripId(1).tripName("Family Vacation")
+                .tripId(3).tripName("Family Vacation")
                 .startDate(LocalDate.parse("2023-08-15", DateTimeFormatter.ISO_DATE))
                 .endDate(LocalDate.parse("2023-08-25", DateTimeFormatter.ISO_DATE))
-                .itineraryId(5).build().toItineraryDTO();
+                .itineraryId(1).build().toItineraryDTO();
             List<ItineraryDTO> itineraryList = new ArrayList<>();
             itineraryList.add(itinerary);
-            lenient().when(mockItineraryService.getItineraryListFromCSV(1))
+            lenient().when(mockItineraryService.getItineraryListFromCSV(3))
                 .thenReturn(itineraryList);
 
-            //when
-            List<ItineraryDTO> result = itineraryService.getItineraryListFromCSV(1);
+            //given,when
+            List<ItineraryDTO> result = itineraryService.getItineraryListFromCSV(3);
+            tripService.deleteTripFromCsv(3);
 
             //then
             Assertions.assertEquals(result.get(0).getId(), itineraryList.get(0).getId());
@@ -119,11 +120,74 @@ public class ItineraryServiceTest {
         @DisplayName("특정 여정을 삭제할 수 있다.")
         void _willSuccess() throws ItineraryNotFoundException {
             //given, when
-            boolean result = itineraryService.deleteItineraryFromCSV(1, 5);
+            postFileCSV();
+            boolean result = itineraryService.deleteItineraryFromCSV(3, 1);
+            tripService.deleteTripFromCsv(3);
 
             //then
             Assertions.assertTrue(result);
         }
     }
+
+    public void postFileJSON(){
+        FileWriter fw = null;
+        try {
+            fw = new FileWriter("src/main/resources/trip/json/trip_3.json");
+            String text = "{\n"
+                + "  \"trip_id\": 3,\n"
+                + "  \"trip_name\": \"Family Vacation\",\n"
+                + "  \"start_date\": \"2023-07-15\",\n"
+                + "  \"end_date\": \"2023-07-20\",\n"
+                + "  \"itineraries\": [\n"
+                + "    {\n"
+                + "      \"itinerary_id\": 1,\n"
+                + "      \"departure_place\": \"City A\",\n"
+                + "      \"destination\": \"City B\",\n"
+                + "      \"departure_time\": \"2023-07-15T08:00:00\",\n"
+                + "      \"arrival_time\": \"2023-07-15T10:00:00\",\n"
+                + "      \"check_in\": \"2023-07-15T12:00:00\",\n"
+                + "      \"check_out\": \"2023-07-30T10:00:00\"\n"
+                + "    }\n"
+                + "  ]\n"
+                + "}";
+            fw.write(text);
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            try {
+                if (fw !=null) {
+                    fw.close();
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public void postFileCSV(){
+        FileWriter fw = null;
+        try {
+            fw = new FileWriter("src/main/resources/trip/csv/trip_3.csv");
+            String text = "trip_id,trip_name,start_date,end_date,itinerary_id,departure,destination,departure_time,arrival_time,check_in,check_out\n"
+                + "3,Family Vacation,2023-08-15,2023-08-25,1,New York,Los Angeles,2023-07-15T08:00:00,2023-07-15T10:00:00,,\n"
+                + "3,Family Vacation,2023-08-15,2023-08-25,2,,,2023-07-15T08:00:00,2023-07-15T08:00:00,2023-07-15T08:00:00,2023-07-15T08:00:00\n"
+                + "3,Family Vacation,2023-08-15,2023-08-25,3,Los Angeles,Las Vegas,2023-07-15T08:00:00,2023-07-15T08:00:00,,\n"
+                + "3,Family Vacation,2023-08-15,2023-08-25,4,,,2023-07-15T08:00:00,2023-07-15T08:00:00,2023-07-15T08:00:00,2023-07-15T08:00:00\n"
+                + "3,Family Vacation,2023-08-15,2023-08-25,5,Las Vegas,New York,2023-07-15T08:00:00,2023-07-15T08:00:00,,";
+            fw.write(text);
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            try {
+                if (fw !=null) {
+                    fw.close();
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+
 
 }

--- a/src/test/java/domain/itinerary/service/ItineraryServiceTest.java
+++ b/src/test/java/domain/itinerary/service/ItineraryServiceTest.java
@@ -45,13 +45,13 @@ public class ItineraryServiceTest {
             postFileJSON();
             List<ItineraryDTO> itineraryList = new ArrayList<>();
             itineraryList.add(ItineraryDTO.builder().id(1).build());
-            lenient().when(mockItineraryService.getItineraryListFromJson(3)).thenReturn(itineraryList);
+            lenient().when(mockItineraryService.getItineraryListFromJson(999)).thenReturn(itineraryList);
 
             //when
-            List<ItineraryDTO> result = itineraryService.getItineraryListFromJson(3);
+            List<ItineraryDTO> result = itineraryService.getItineraryListFromJson(999);
 
             //then
-            tripService.deleteTripFromJson(3);
+            tripService.deleteTripFromJson(999);
             Assertions.assertEquals(result.get(0).getId(), itineraryList.get(0).getId());
         }
 
@@ -59,7 +59,7 @@ public class ItineraryServiceTest {
         @DisplayName("특정 여행 기록이 없으면 조회할 수 없다.")
         void tripFileNotFound_willFail() {
             Throwable exception = assertThrows(TripFileNotFoundException.class, () -> {
-                tripService.getTripFromJson(5);
+                tripService.getTripFromJson(1000);
             });
             assertEquals("여행 파일을 찾을 수 없습니다.", exception.getMessage());
         }
@@ -76,8 +76,8 @@ public class ItineraryServiceTest {
         void _willSuccess() throws ItineraryNotFoundException {
             //given, when
             postFileJSON();
-            boolean result = itineraryService.deleteItineraryFromJson(3, 1);
-            tripService.deleteTripFromJson(3);
+            boolean result = itineraryService.deleteItineraryFromJson(999, 1);
+            tripService.deleteTripFromJson(999);
 
             //then
             Assertions.assertTrue(result);
@@ -94,18 +94,18 @@ public class ItineraryServiceTest {
             //given
             postFileCSV();
             ItineraryDTO itinerary = TripCsvDTO.builder()
-                .tripId(3).tripName("Family Vacation")
+                .tripId(999).tripName("Family Vacation")
                 .startDate(LocalDate.parse("2023-08-15", DateTimeFormatter.ISO_DATE))
                 .endDate(LocalDate.parse("2023-08-25", DateTimeFormatter.ISO_DATE))
                 .itineraryId(1).build().toItineraryDTO();
             List<ItineraryDTO> itineraryList = new ArrayList<>();
             itineraryList.add(itinerary);
-            lenient().when(mockItineraryService.getItineraryListFromCSV(3))
+            lenient().when(mockItineraryService.getItineraryListFromCSV(999))
                 .thenReturn(itineraryList);
 
             //given,when
-            List<ItineraryDTO> result = itineraryService.getItineraryListFromCSV(3);
-            tripService.deleteTripFromCsv(3);
+            List<ItineraryDTO> result = itineraryService.getItineraryListFromCSV(999);
+            tripService.deleteTripFromCsv(999);
 
             //then
             Assertions.assertEquals(result.get(0).getId(), itineraryList.get(0).getId());
@@ -121,8 +121,8 @@ public class ItineraryServiceTest {
         void _willSuccess() throws ItineraryNotFoundException {
             //given, when
             postFileCSV();
-            boolean result = itineraryService.deleteItineraryFromCSV(3, 1);
-            tripService.deleteTripFromCsv(3);
+            boolean result = itineraryService.deleteItineraryFromCSV(999, 1);
+            tripService.deleteTripFromCsv(999);
 
             //then
             Assertions.assertTrue(result);
@@ -132,9 +132,9 @@ public class ItineraryServiceTest {
     public void postFileJSON(){
         FileWriter fw = null;
         try {
-            fw = new FileWriter("src/main/resources/trip/json/trip_3.json");
+            fw = new FileWriter("src/main/resources/trip/json/trip_999.json");
             String text = "{\n"
-                + "  \"trip_id\": 3,\n"
+                + "  \"trip_id\": 999,\n"
                 + "  \"trip_name\": \"Family Vacation\",\n"
                 + "  \"start_date\": \"2023-07-15\",\n"
                 + "  \"end_date\": \"2023-07-20\",\n"
@@ -167,13 +167,13 @@ public class ItineraryServiceTest {
     public void postFileCSV(){
         FileWriter fw = null;
         try {
-            fw = new FileWriter("src/main/resources/trip/csv/trip_3.csv");
+            fw = new FileWriter("src/main/resources/trip/csv/trip_999.csv");
             String text = "trip_id,trip_name,start_date,end_date,itinerary_id,departure,destination,departure_time,arrival_time,check_in,check_out\n"
-                + "3,Family Vacation,2023-08-15,2023-08-25,1,New York,Los Angeles,2023-07-15T08:00:00,2023-07-15T10:00:00,,\n"
-                + "3,Family Vacation,2023-08-15,2023-08-25,2,,,2023-07-15T08:00:00,2023-07-15T08:00:00,2023-07-15T08:00:00,2023-07-15T08:00:00\n"
-                + "3,Family Vacation,2023-08-15,2023-08-25,3,Los Angeles,Las Vegas,2023-07-15T08:00:00,2023-07-15T08:00:00,,\n"
-                + "3,Family Vacation,2023-08-15,2023-08-25,4,,,2023-07-15T08:00:00,2023-07-15T08:00:00,2023-07-15T08:00:00,2023-07-15T08:00:00\n"
-                + "3,Family Vacation,2023-08-15,2023-08-25,5,Las Vegas,New York,2023-07-15T08:00:00,2023-07-15T08:00:00,,";
+                + "999,Family Vacation,2023-08-15,2023-08-25,1,New York,Los Angeles,2023-07-15T08:00:00,2023-07-15T10:00:00,,\n"
+                + "999,Family Vacation,2023-08-15,2023-08-25,2,,,2023-07-15T08:00:00,2023-07-15T08:00:00,2023-07-15T08:00:00,2023-07-15T08:00:00\n"
+                + "999,Family Vacation,2023-08-15,2023-08-25,3,Los Angeles,Las Vegas,2023-07-15T08:00:00,2023-07-15T08:00:00,,\n"
+                + "999,Family Vacation,2023-08-15,2023-08-25,4,,,2023-07-15T08:00:00,2023-07-15T08:00:00,2023-07-15T08:00:00,2023-07-15T08:00:00\n"
+                + "999,Family Vacation,2023-08-15,2023-08-25,5,Las Vegas,New York,2023-07-15T08:00:00,2023-07-15T08:00:00,,";
             fw.write(text);
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/test/java/domain/trip/service/TripServiceTest.java
+++ b/src/test/java/domain/trip/service/TripServiceTest.java
@@ -82,7 +82,7 @@ public class TripServiceTest {
         void tripFileNotFound_willFail() {
             // given, when, then
             Throwable exception = assertThrows(TripFileNotFoundException.class, () -> {
-                tripService.getTripFromJson(2);
+                tripService.getTripFromJson(105);
             });
             assertEquals("여행 파일을 찾을 수 없습니다.", exception.getMessage());
         }
@@ -99,7 +99,7 @@ public class TripServiceTest {
             // Test 를 위해 삭제할 파일 생성
             FileWriter fw = null;
             try {
-                fw = new FileWriter("src/main/resources/trip/json/trip_1.json");
+                fw = new FileWriter("src/main/resources/trip/json/trip_105.json");
             } catch (Exception e) {
                 e.printStackTrace();
             } finally {
@@ -113,7 +113,7 @@ public class TripServiceTest {
             }
 
             // when
-            boolean result = tripService.deleteTripFromJson(1);
+            boolean result = tripService.deleteTripFromJson(105);
 
             // then
             Assertions.assertTrue(result);

--- a/src/test/java/domain/trip/service/TripServiceTest.java
+++ b/src/test/java/domain/trip/service/TripServiceTest.java
@@ -203,7 +203,7 @@ public class TripServiceTest {
             // Test 를 위해 삭제할 파일 생성
             FileWriter fw = null;
             try {
-                fw = new FileWriter("src/main/resources/trip/csv/trip_1.csv");
+                fw = new FileWriter("src/main/resources/trip/csv/trip_106.csv");
             } catch (Exception e) {
                 e.printStackTrace();
             } finally {
@@ -217,7 +217,7 @@ public class TripServiceTest {
             }
 
             // when
-            boolean result = tripService.deleteTripFromCsv(1);
+            boolean result = tripService.deleteTripFromCsv(106);
 
             // then
             Assertions.assertTrue(result);

--- a/src/test/java/domain/trip/service/TripServiceTest.java
+++ b/src/test/java/domain/trip/service/TripServiceTest.java
@@ -82,7 +82,7 @@ public class TripServiceTest {
         void tripFileNotFound_willFail() {
             // given, when, then
             Throwable exception = assertThrows(TripFileNotFoundException.class, () -> {
-                tripService.getTripFromJson(105);
+                tripService.getTripFromJson(997);
             });
             assertEquals("여행 파일을 찾을 수 없습니다.", exception.getMessage());
         }
@@ -99,7 +99,7 @@ public class TripServiceTest {
             // Test 를 위해 삭제할 파일 생성
             FileWriter fw = null;
             try {
-                fw = new FileWriter("src/main/resources/trip/json/trip_105.json");
+                fw = new FileWriter("src/main/resources/trip/json/trip_998.json");
             } catch (Exception e) {
                 e.printStackTrace();
             } finally {
@@ -113,7 +113,7 @@ public class TripServiceTest {
             }
 
             // when
-            boolean result = tripService.deleteTripFromJson(105);
+            boolean result = tripService.deleteTripFromJson(998);
 
             // then
             Assertions.assertTrue(result);
@@ -123,7 +123,7 @@ public class TripServiceTest {
         @DisplayName("해달 여행 기록이 없으면 여행 기록을 삭제할 수 없다.")
         void tripFileNotFound_willFail() {
             // given, when
-            boolean result = tripService.deleteTripFromJson(1);
+            boolean result = tripService.deleteTripFromJson(996);
 
             // then
             Assertions.assertFalse(result);
@@ -203,7 +203,7 @@ public class TripServiceTest {
             // Test 를 위해 삭제할 파일 생성
             FileWriter fw = null;
             try {
-                fw = new FileWriter("src/main/resources/trip/csv/trip_106.csv");
+                fw = new FileWriter("src/main/resources/trip/csv/trip_998.csv");
             } catch (Exception e) {
                 e.printStackTrace();
             } finally {
@@ -217,7 +217,7 @@ public class TripServiceTest {
             }
 
             // when
-            boolean result = tripService.deleteTripFromCsv(106);
+            boolean result = tripService.deleteTripFromCsv(998);
 
             // then
             Assertions.assertTrue(result);


### PR DESCRIPTION
[ItineraryServiceTest] : 여정 조회 및 삭제 테스트

- 새로운 trip_999.json, trip_999.csv을 생성 후, 해당 파일 내의 여정 조회
- 새로운 파일 내의 여정 삭제 

[TripServiceTest] : 여행 조회 및 삭제 테스트
- 새로운 trip_105.json, trip_106.csv를 생성 후, 해당 여행 파일 삭제


