### PR TITLE
ci: 테스트 검사 추가

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -27,9 +27,12 @@ jobs:
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-        
+
     - name: Build with Gradle
-      run: ./gradlew build -x test
+      uses: gradle/gradle-build-action@v2.6.0
+      with:
+        arguments: build
+        cache-read-only: ${{ github.ref != 'ref/heads/main' && github.ref != 'ref/heads/develop' }}
   
     - name: Publish result of unit test
       uses: EnricoMi/publish-unit-test-result-action@v2


### PR DESCRIPTION
- 지난 CI 테스트 검사에 오류가 발생해 테스트 검사는 수행하지 않도록 수정했었습니다. 
- 오류 발생의 이유가 develop에는 여행 기록을 저장할 폴더 자체가 없었기 때문인 것 같습니다. 

- 샘플 파일을 추가하여 경로를 찾을 수 있게 되었으므로 테스트 검사에 문제가 없어져, 다시 테스트 검사를 수행하도록 스크립트를 수정하고자 합니다. 
- 짧은 시간 내에 프로젝트를 마무리 하기 위해 좀 더 빠른 수정이 어려웠던 점 양해 부탁드립니다. 

- 샘플 파일 PR이 먼저 Merge 된 이후 테스트가 통과되면 해당 PR Merge 하겠습니다. 
- 감사합니다!